### PR TITLE
Fixed bugs introduced in 0.4.1 and made Enable-DscDebug optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ You'll need the test-kitchen & kitchen-dsc gems installed in your system, along 
   * Name of the configuration to run, defaults to the suite name.
 * configuration_data_variable
   * Name of the variable in the configuration_script that contains the ConfigurationData hashtable
+* enable_dsc_debug
+  * Defaults to false
+  * Specifies whether to run the "Enable-DscDebug -BreakAll" command before applying the DSC configuration. Only applicable to wmf5.
 * dsc_local_configuration_manager_version
   * Defaults to 'wmf4' ()
   * Identifies what version of the LCM is in place

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -28,6 +28,7 @@ module Kitchen
         provisioner.instance.suite.name
       end
       default_config :configuration_data_variable
+	  default_config :enable_dsc_debug, false
 
       default_config :dsc_local_configuration_manager_version, 'wmf4'
       default_config :dsc_local_configuration_manager, {
@@ -91,7 +92,7 @@ module Kitchen
                 ConfigurationMode = '#{lcm_config[:configuration_mode]}'
                 ConfigurationModeFrequencyMins = #{lcm_config[:configuration_mode_frequency_mins].nil? ? '15' : lcm_config[:configuration_mode_frequency_mins]}
                 RebootNodeIfNeeded = [bool]::Parse('#{lcm_config[:reboot_if_needed]}')
-                RefreshFrequencyMins = #{lcm_config[:refresh_frequency_mins].nil? ? '30' : lcm[:refresh_frequency_mins]}
+                RefreshFrequencyMins = #{lcm_config[:refresh_frequency_mins].nil? ? '30' : lcm_config[:refresh_frequency_mins]}
                 RefreshMode = '#{lcm_config[:refresh_mode]}'
               }
             }
@@ -102,7 +103,7 @@ module Kitchen
 
         $null = SetupLCM
         Set-DscLocalConfigurationManager -Path ./SetupLCM
-        if ($PSVersionTable.PSVersion.Major -ge 5) {Enable-DscDebug}
+        if ([bool]::Parse('#{config[:enable_dsc_debug]}') -and $PSVersionTable.PSVersion.Major -ge 5) {Enable-DscDebug -BreakAll}
         EOH
 
         wrap_shell_code(full_lcm_configuration_script)

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -28,7 +28,7 @@ module Kitchen
         provisioner.instance.suite.name
       end
       default_config :configuration_data_variable
-	  default_config :enable_dsc_debug, false
+      default_config :enable_dsc_debug, false
 
       default_config :dsc_local_configuration_manager_version, 'wmf4'
       default_config :dsc_local_configuration_manager, {


### PR DESCRIPTION
* Made the Enable-DscDebug cmdlet optional and have it default to false to
allow compatibility of previous kitchen-dsc configurations. Previous to this change, the cmdlet was always run on WMF5 and caused my DSC configuration to not finish which is changed behavior from previous versions
* Line 94 of dsc.rb had a typo in the variable name, which ended up
referencing  a variable that did not exist
* Line 105 of dsc.rb was using Enable-DscDebug without the "BreakAll"
parameter which caused the command to fail.