### PR TITLE
Add the ability to run a prerequisite PowerShell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ You will see a delay in the return of the run details due to an difference in ho
     * refresh_frequency_mins = 15               # 30 on wmf5
     * refresh_mode = 'PUSH'
 
+* prerequisite_script
+  * Path to a prerequisite PowerShell script that will run after the module has been copied to C:\Program Files\WindowsPowerShell\Modules but before the DSC configuration is run
+
 ### Specific to repository style testing
 * modules_path
   * Defaults to 'modules'.

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -124,6 +124,8 @@ module Kitchen
         end
         info('Staging DSC configuration script for copy to the SUT')
         prepare_configuration_script
+        info('Staging prerequisite script for copy to the SUT')
+        prepare_prerequisite_script
       end
 
       # Disable line length check, it is all logging and embedded script.
@@ -131,6 +133,11 @@ module Kitchen
       def prepare_command
         configuration_data_variable = config[:configuration_data_variable].nil? ? 'ConfigurationData' : config[:configuration_data_variable]
         info('Moving DSC Resources onto PSModulePath')
+        if !config[:prerequisite_script].nil?
+            prerequisite_script = File.basename(config[:prerequisite_script])
+            run_prerequisite_script_command = ['&(Join-Path "', config[:root_path], '" -ChildPath "prerequisites" | Join-Path -ChildPath "', prerequisite_script, '")'].join
+            info("Running the prerequisite script #{prerequisite_script}")
+        end
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
@@ -138,6 +145,9 @@ module Kitchen
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |
               copy-item -destination $env:programfiles/windowspowershell/modules/ -recurse -force
           }
+          
+          #{run_prerequisite_script_command unless run_prerequisite_script_command.nil?}
+            
           if (-not (test-path 'c:/configurations'))
           {
             mkdir 'c:/configurations' | out-null
@@ -267,8 +277,21 @@ module Kitchen
         configuration_script_path = File.join(config[:kitchen_root], configuration_script_file)
         sandbox_configuration_script_path = File.join(sandbox_path, sandboxed_configuration_script)
         FileUtils.mkdir_p(File.dirname(sandbox_configuration_script_path))
-        debug("Moving #{configuration_script_path} to #{sandbox_configuration_script_path}")
+        debug("Copying #{configuration_script_path} to #{sandbox_configuration_script_path}")
         FileUtils.cp(configuration_script_path, sandbox_configuration_script_path)
+      end
+
+      def prepare_prerequisite_script
+        if !config[:prerequisite_script].nil?
+          prerequisite_script = File.expand_path(config[:prerequisite_script])
+          sandbox_prerequisite_folder = File.join(sandbox_path, 'prerequisites')
+          sandbox_prerequisite_script_path = File.join(sandbox_prerequisite_folder, File.basename(prerequisite_script))
+          FileUtils.mkdir_p(sandbox_prerequisite_folder)
+          debug("Copying #{prerequisite_script} to #{sandbox_prerequisite_script_path}")
+          FileUtils.cp(prerequisite_script, sandbox_prerequisite_script_path)
+        else
+          debug("The prerequisite script will not be copied over or run because prerequisite_script was not defined")
+        end
       end
     end
   end


### PR DESCRIPTION
One of the issues I've struggled with is installing the prerequisite modules on my Test-Kitchen guest when testing a DSC configuration or composite resource. I had originally used a provisioning script via Vagrant but I have since changed drivers and do not have the same capabilities.

My solution was to add the ability to run a prerequisite PowerShell script with Kitchen-DSC to install those prerequisite modules.

Here is a sample of the script I run which grabs the dependencies dynamically from the module manifest and installs them via nuget (I hope this may be useful to others):
```
(Get-Module -Name (Get-ChildItem -Path "$env:TEMP\kitchen" -Filter "*.psd1" -Recurse | Select-Object -First 1).FullName -ListAvailable).RequiredModules | ForEach-Object {

    $fullyQualifiedName = @{ModuleName=$_.Name; ModuleVersion=$_.Version}
    $localModule = Get-Module -FullyQualifiedName $fullyQualifiedName -ListAvailable -ErrorAction 'SilentlyContinue'

    if ($localModule.Version -ne $_.Version) {

        Find-Module -Name $_.Name -RequiredVersion $_.Version -Repository 'InternalNugetRepo' -ErrorAction 'Stop' | Install-Module -Force -ErrorAction 'Stop' 
    }
}
```