### PR TITLE
Fixes duplicate Repository parameter being supplied to Install-Module

### DIFF
--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -144,10 +144,9 @@ module Kitchen
           params = if powershell_module.is_a? Hash
                      keys = powershell_module.keys.reject { |k| k.to_s.downcase! == 'force' }
                      unless keys.any? { |k| k.to_s.downcase! == 'repository' }
-                       keys.push(:repository)
                        powershell_module[:repository] = psmodule_repository_name
                      end
-                     keys.map do |key|
+                     powershell_module.keys.map do |key|
                        "-#{key} #{powershell_module[key]}"
                      end.join(' ')
                    else


### PR DESCRIPTION
This pull request fixes an issue where the Repository parameter is supplied twice to the Install-Module cmdlet on the converge portion for every test suite run after the first suite (second suite and beyond).

It seems that the keys array contained two values of repository after the first run.

I was having that issue with the following provisioner configuration:
```
provisioner:
  name: dsc
  dsc_local_configuration_manager_version: wmf5
  dsc_local_configuration_manager:
    action_after_reboot: StopConfiguration
    allow_module_overwrite: false
    certificate_id: 29010115C9C0C0B2C9272617DBAF161763FF2D7E
    configuration_mode: ApplyOnly
    configuration_mode_frequency_mins: 30
    debug_mode: None
    reboot_if_needed: false
    refresh_frequency_mins: 30
    refresh_mode: PUSH
  configuration_script: Test_Kitchen_DSC_Configuration.ps1
  configuration_data_variable: ConfigData
  gallery_name: CompanyNuget
  modules_from_gallery:
    - name: xPSDesiredStateConfiguration
      requiredversion: 3.9.0.0
    - name: xNetworking
      requiredversion: 2.7.0.0
    - name: xComputerManagement
      requiredversion: 1.4.0.0
```