### PR TITLE
Output mof generation errors

### DIFF
--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -80,9 +80,13 @@ module Kitchen
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
 
+          if(Test-Path c:/configurations)
+          {
+              Remove-Item -Recurse -Force c:/configurations
+          }
+
           $Error.clear()
 
-          Remove-Item -Recurse -Force c:/configurations
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
           {
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -94,7 +94,8 @@ module Kitchen
           {
             throw "Failed to find $ConfigurationScriptPath"
           }
-          invoke-expression (get-content $ConfigurationScriptPath -raw)
+          invoke-expression (get-content $ConfigurationScriptPath -raw) -ErrorVariable errors
+          $errors
           if (-not (get-command #{config[:configuration_name]}))
           {
             throw "Failed to create a configuration command #{config[:configuration_name]}"

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -79,6 +79,7 @@ module Kitchen
         info("Moving DSC Resources onto PSModulePath")
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
+          Remove-Item -Recurse -Force c:/configurations
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
           {
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -95,7 +95,12 @@ module Kitchen
             throw "Failed to find $ConfigurationScriptPath"
           }
           invoke-expression (get-content $ConfigurationScriptPath -raw) -ErrorVariable errors
-          $errors
+          
+          if($errors -ne $null)
+          {
+            exit 1
+          }
+          
           if (-not (get-command #{config[:configuration_name]}))
           {
             throw "Failed to create a configuration command #{config[:configuration_name]}"


### PR DESCRIPTION
This PR makes it easier to work out why the MOF file isn't being generated (eg. Due to a syntax error in your DSC)

Additionally, the generated MOF is recreated each time the `converge` kitchen step is run, as I was finding that I would have to manually remove the file in order to properly test DSC re-runs on the same VM.