### PR TITLE
Copy config folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ You will see a delay in the return of the run details due to an difference in ho
 * configuration_script_folder
   * Defaults to 'examples'.
   * The location of a PowerShell script(s) containing the DSC configuration command(s).
+  * The whole content of the folder will be copied to the node
 
 * configuration_script
   * Defaults to 'dsc_configuration.ps1'
   * The name of the PowerShell script containing the DSC configuration command(s) (and possibly configuration data)
+  * can be a relative path from the configuration_script_folder
+  * the configuration script is dot sourced
+  * if the configuration_script is set to `MOF` it will not execute a configuration script but copy
+  the content of configuration_script_folder as-is, so that MOF from those directories can be applied.
 
 * configuration_name
-  * Name of the configuration to run, defaults to the suite name.
+  * Name of the configurations to run, defaults to the suite name.
+  * This can be an array of configuration from the same configuration script.
+  * When applying MOFs directly, the path expected is `configuration_script_folder\configuration_name\*.mof`
 
 * configuration_data
   * A YAML representation of what should be passed to the configuration.
@@ -73,11 +80,11 @@ You will see a delay in the return of the run details due to an difference in ho
 * gallery_uri
   * URI for a custom PowerShell gallery feed.
 
-### Specific to repository style testing
 * modules_path
   * Defaults to 'modules'.
   * Points to the location of modules containing DSC resources to upload
   * This path is relative to the root of the repository (the location of the .kitchen.yml).
+  * this works for both Repository and Resource style testing
 
 ## Example 
 
@@ -106,3 +113,23 @@ suite:
           - nodename: localhost
             role: webserver
 ```
+
+Now you can also:
+  - apply MOF(s) directly
+  - copy the whole content of the `configuration_script_folder`, 
+  allowing more complex configs
+  - Copy modules from module_path to the node in Resource Repo
+  - store your kitchen.yml file in the parent folder of a Module where
+  the structure follows this:
+  ```
+  MODULENAME
+  │   .kitchen.yml
+  │
+  ├───ModuleName
+  │   │   ModuleName.psd1
+  │   │
+  │   └───DscResources
+  └───Modules
+      └───xNetworking
+    ```
+  

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -79,6 +79,7 @@ module Kitchen
         info("Moving DSC Resources onto PSModulePath")
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
+          $configuration_name = #{config[:configuration_name]}
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
           {
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |
@@ -93,7 +94,7 @@ module Kitchen
           {
             throw "Failed to find $ConfigurationScriptPath"
           }
-          invoke-expression (get-content $ConfigurationScriptPath -raw)
+          . $ConfigurationScriptPath
           if (-not (get-command #{config[:configuration_name]}))
           {
             throw "Failed to create a configuration command #{config[:configuration_name]}"

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -79,7 +79,7 @@ module Kitchen
         info("Moving DSC Resources onto PSModulePath")
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
-          $configuration_name = #{config[:configuration_name]}
+          $configuration_name = '#{config[:configuration_name]}'
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
           {
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -258,7 +258,7 @@ module Kitchen
 
       def powershell_module?
         File.exist?(File.join(config[:kitchen_root], "#{module_name}.psd1")) ||
-        File.exist?(File.join(config[:kitchen_root], module_name, "#{module_name}.psd1")
+        File.exist?(File.join(config[:kitchen_root], module_name, "#{module_name}.psd1"))
       end
 
       def list_files(path)
@@ -281,7 +281,7 @@ module Kitchen
         sandbox_module_path = File.join(sandbox_path, "modules")
         base = config[:kitchen_root]
 
-        if File.exist?(File.join(base, module_name, "#{module_name}.psd1")
+        if File.exist?(File.join(base, module_name, "#{module_name}.psd1"))
           module_dir = File.join(base, module_name)
           info("Staging Resource Module from #{module_dir}")
           copy_if_dir_exists(module_dir, sandbox_module_path)
@@ -331,7 +331,7 @@ module Kitchen
       def prepare_configuration_script
         sandbox_configuration_path = File.join(sandbox_path, 'configuration')
         debug("Local sandbox folder: #{sandbox_configuration_path}")
-        configuration_path = File.join(config[:kitchen_root], "#{config[:configuration_script_folder]}/.")
+        configuration_path = File.join(config[:kitchen_root], config[:configuration_script_folder])
         info("Configuration Source folder to copy: #{configuration_path}")
         FileUtils.mkdir_p(sandbox_configuration_path)
         debug("Copying #{configuration_path} to #{sandbox_configuration_path}")

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -79,8 +79,6 @@ module Kitchen
         info("Moving DSC Resources onto PSModulePath")
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
-          $ConfigurationName = "#{config[:configuration_name]}"
-          
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
           {
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |
@@ -95,7 +93,7 @@ module Kitchen
           {
             throw "Failed to find $ConfigurationScriptPath"
           }
-          . $ConfigurationScriptPath
+          invoke-expression (get-content $ConfigurationScriptPath -raw)
           if (-not (get-command #{config[:configuration_name]}))
           {
             throw "Failed to create a configuration command #{config[:configuration_name]}"
@@ -260,8 +258,7 @@ module Kitchen
       end
 
       def sandboxed_configuration_script
-        configuration_script_file = File.join(config[:configuration_script_folder], config[:configuration_script])
-        File.join('configuration', configuration_script_file)
+        File.join("configuration", config[:configuration_script])
       end
 
       def pad(depth = 0)
@@ -283,11 +280,12 @@ module Kitchen
 
       def prepare_configuration_script
         sandbox_configuration_path = File.join(sandbox_path, 'configuration')
-        sandbox_configuration_path_folder = File.join(sandbox_configuration_path, config[:configuration_script_folder])
-        configuration_path = File.join(config[:kitchen_root], config[:configuration_script_folder])
-        FileUtils.mkdir_p(sandbox_configuration_path_folder)
-        debug("Moving #{configuration_path} to #{sandbox_configuration_path_folder}")
-        FileUtils.cp_r(configuration_path, sandbox_configuration_path_folder)
+        debug("Local sandbox folder: #{sandbox_configuration_path}")
+        configuration_path = File.join(config[:kitchen_root], "#{config[:configuration_script_folder]}/.")
+        info("Configuration Source folder to copy: #{configuration_path}")
+        FileUtils.mkdir_p(sandbox_configuration_path)
+        debug("Copying #{configuration_path} to #{sandbox_configuration_path}")
+        FileUtils.cp_r(configuration_path, sandbox_configuration_path)
       end
     end
   end

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -91,7 +91,7 @@ module Kitchen
           copy-item -destination $env:programfiles/windowspowershell/modules/ -recurse -force
         }
 
-        $ConfigurationScriptPath = Join-path #{config[:root_path]} #{sandboxed_configuration_script}
+        $ConfigurationScriptPath = Join-path '#{config[:root_path]}' #{sandboxed_configuration_script}
         if('#{config[:configuration_script]}' -ne 'MOF') {
           if (-not (test-path $ConfigurationScriptPath))
             {
@@ -119,8 +119,8 @@ module Kitchen
   
             if('#{config[:configuration_script]}' -eq 'MOF')
             {
-              $SourceMof = Join-Path '#{sandboxed_mof_path}' '#{configuration}.mof'
-              Copy-Item -force $SourceMof 'c:/configurations/localhost.mof'
+              $SourceMof = '#{sandboxed_mof_path}\*' 
+              Copy-Item -force -recurse $SourceMof 'c:/configurations/'
             }
             elseif (-not (get-command #{configuration}))
             {

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -129,9 +129,8 @@ module Kitchen
             else
             {
               #{configuration_data_assignment unless config[:configuration_data].nil?}
-
               try{
-                $null = #{configuration} -outputpath c:/configurations/#{configuration} #{"-configurationdata $" + configuration_data_variable}
+                $null = #{configuration} -outputpath 'c:/configurations/#{configuration}' #{"-configurationdata $" + configuration_data_variable}
               }
               catch{
               }
@@ -280,13 +279,14 @@ module Kitchen
       def prepare_resource_style_directory
         sandbox_module_path = File.join(sandbox_path, "modules")
         base = config[:kitchen_root]
+        FileUtils.mkdir_p(sandbox_module_path)
 
         if File.exist?(File.join(base, module_name, "#{module_name}.psd1"))
           module_dir = File.join(base, module_name)
           info("Staging Resource Module from #{module_dir}")
           copy_if_dir_exists(module_dir, sandbox_module_path)
         else
-          info("Staging Resource Module from #{base}")
+          debug("Staging Resource Module from #{base} to #{sandbox_module_path}")
           copy_if_dir_exists(base, sandbox_module_path)
         end
         prepare_repo_style_directory
@@ -329,13 +329,13 @@ module Kitchen
       end
 
       def prepare_configuration_script
-        sandbox_configuration_path = File.join(sandbox_path, 'configuration')
+        sandbox_configuration_path = File.join(sandbox_path, 'configuration',config[:configuration_script_folder])
         debug("Local sandbox folder: #{sandbox_configuration_path}")
         configuration_path = File.join(config[:kitchen_root], config[:configuration_script_folder])
         info("Configuration Source folder to copy: #{configuration_path}")
         FileUtils.mkdir_p(sandbox_configuration_path)
         debug("Copying #{configuration_path} to #{sandbox_configuration_path}")
-        FileUtils.cp_r(configuration_path, sandbox_configuration_path)
+        FileUtils.cp_r("#{configuration_path}/.", sandbox_configuration_path)
       end
 
       def ensure_array(thing)

--- a/lib/kitchen/provisioner/dsc.rb
+++ b/lib/kitchen/provisioner/dsc.rb
@@ -79,6 +79,8 @@ module Kitchen
         info("Moving DSC Resources onto PSModulePath")
         info("Generating the MOF script for the configuration #{config[:configuration_name]}")
         stage_resources_and_generate_mof_script = <<-EOH
+          $ConfigurationName = "#{config[:configuration_name]}"
+          
           if (Test-Path (join-path #{config[:root_path]} 'modules'))
           {
             dir ( join-path #{config[:root_path]} 'modules/*') -directory |
@@ -93,7 +95,7 @@ module Kitchen
           {
             throw "Failed to find $ConfigurationScriptPath"
           }
-          invoke-expression (get-content $ConfigurationScriptPath -raw)
+          . $ConfigurationScriptPath
           if (-not (get-command #{config[:configuration_name]}))
           {
             throw "Failed to create a configuration command #{config[:configuration_name]}"
@@ -258,7 +260,8 @@ module Kitchen
       end
 
       def sandboxed_configuration_script
-        File.join("configuration", config[:configuration_script])
+        configuration_script_file = File.join(config[:configuration_script_folder], config[:configuration_script])
+        File.join('configuration', configuration_script_file)
       end
 
       def pad(depth = 0)
@@ -279,12 +282,12 @@ module Kitchen
       end
 
       def prepare_configuration_script
-        configuration_script_file = File.join(config[:configuration_script_folder], config[:configuration_script])
-        configuration_script_path = File.join(config[:kitchen_root], configuration_script_file)
-        sandbox_configuration_script_path = File.join(sandbox_path, sandboxed_configuration_script)
-        FileUtils.mkdir_p(File.dirname(sandbox_configuration_script_path))
-        debug("Moving #{configuration_script_path} to #{sandbox_configuration_script_path}")
-        FileUtils.cp(configuration_script_path, sandbox_configuration_script_path)
+        sandbox_configuration_path = File.join(sandbox_path, 'configuration')
+        sandbox_configuration_path_folder = File.join(sandbox_configuration_path, config[:configuration_script_folder])
+        configuration_path = File.join(config[:kitchen_root], config[:configuration_script_folder])
+        FileUtils.mkdir_p(sandbox_configuration_path_folder)
+        debug("Moving #{configuration_path} to #{sandbox_configuration_path_folder}")
+        FileUtils.cp_r(configuration_path, sandbox_configuration_path_folder)
       end
     end
   end


### PR DESCRIPTION
This PR is backward compatible but adds a few features.
Now you can also:
  - apply MOF(s) directly (fix #27 )
  - copy the whole content of the `configuration_script_folder`, 
  allowing more complex configs
  - Copy and installs modules from module_path to the node in Resource Repo
  - store your `.kitchen.yml` file in the root folder of a Module where
  the structure follows this:
  ```
  MODULENAME
  │   .kitchen.yml
  │
  ├───ModuleName
  │   │   ModuleName.psd1
  │   │
  │   └───DscResources
  └───Modules
      └───xNetworking
```
Note: The kitchen root folder **must** have the same name as the Module folder (here `ModuleName`)
  